### PR TITLE
fix: make JSON-LD injection safer

### DIFF
--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -1,12 +1,14 @@
-export function injectLocalBusinessJSONLD() {
-  const NAME = import.meta.env.VITE_SITE_NAME;
-  const TEL = import.meta.env.VITE_PHONE;
-  const EMAIL = import.meta.env.VITE_EMAIL;
-  const CITY = import.meta.env.VITE_CITY;
-  const PROV = import.meta.env.VITE_PROVINCE;
-  const HOURS = (import.meta.env.VITE_HOURS || '').split(';').map((s: string) => s.trim());
-  const AREA = import.meta.env.VITE_SERVICE_AREA;
-  const URL = import.meta.env.VITE_SITE_URL;
+export function injectLocalBusinessJSONLD(
+  env: Record<string, string | undefined> = import.meta.env
+) {
+  const NAME = env.VITE_SITE_NAME;
+  const TEL = env.VITE_PHONE;
+  const EMAIL = env.VITE_EMAIL;
+  const CITY = env.VITE_CITY;
+  const PROV = env.VITE_PROVINCE;
+  const HOURS = (env.VITE_HOURS || '').split(';').map((s: string) => s.trim());
+  const AREA = env.VITE_SERVICE_AREA;
+  const URL = env.VITE_SITE_URL;
 
   const data = {
     '@context': 'https://schema.org',
@@ -24,6 +26,10 @@ export function injectLocalBusinessJSONLD() {
     openingHours: HOURS,
     areaServed: AREA
   };
+
+  if (typeof document === 'undefined') {
+    return data;
+  }
 
   let el = document.getElementById('jsonld-local') as HTMLScriptElement | null;
   if (!el) {

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { injectLocalBusinessJSONLD } from '@/utils/schema';
 
 describe('schema', () => {
   it('injects LocalBusiness JSON-LD', () => {
-    (import.meta as any).env = {
+    const data = injectLocalBusinessJSONLD({
       VITE_SITE_NAME: 'Aserradero X',
       VITE_PHONE: '3511234567',
       VITE_EMAIL: 'hola@test.com',
@@ -12,8 +12,7 @@ describe('schema', () => {
       VITE_HOURS: 'Mo-Fr 09:00-17:00',
       VITE_SERVICE_AREA: 'Córdoba y alrededores',
       VITE_SITE_URL: 'https://example.com'
-    };
-    const data = injectLocalBusinessJSONLD();
+    });
     expect(data['@type']).toBe('LocalBusiness');
     expect(data.name).toBe('Aserradero X');
   });


### PR DESCRIPTION
## Summary
- allow overriding environment values when injecting schema
- avoid errors when running without a DOM

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68a64a36a0d483239b29fe28fac6b678